### PR TITLE
Fixed incorrect user prompting

### DIFF
--- a/welcome/vscode/solve
+++ b/welcome/vscode/solve
@@ -42,7 +42,7 @@ echo -n $'\r'
 if [ "$UID" -ne 0 ]
 then
 	echo "You seem to be running this challenge using 'bash $0' or 'sh $0'."
-	echo "Please run the challenge directly (e.g., without 'bash' or 'sh', just '$0')."
+	echo "Please run the challenge directly (e.g., without 'bash' or 'sh', just './$0')."
 	exit 1
 fi
 


### PR DESCRIPTION
Regarding the suggestion to use `$(realpath $0)` instead of `./$0`, this would expand to the full path of the script, rather than just the relative path. This could be useful if the user is running the script from a different directory and needs to know the full path to the script. However, in this case, it seems that the script is intended to be run from the current directory, so using `./$0` should be sufficient.

Link to issue: https://github.com/pwncollege/welcome-dojo/issues/4#issue-2223881970